### PR TITLE
新しい Order レコードをつくるしくみ

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,9 +11,7 @@ module Bento
     config.generators do |g|
       g.factory_girl dir: 'spec/factories'
     end
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja

--- a/lib/tasks/order.rake
+++ b/lib/tasks/order.rake
@@ -1,0 +1,18 @@
+require_relative './rake_helpers'
+
+namespace :order do
+  desc '平日分の Order レコードを作成する'
+  task create: :environment do
+    today = Time.current.beginning_of_day
+    orders_from_today = Order.where('date > ?', today)
+
+    new_order_date = if orders_from_today.any?
+                       next_weekday_of(orders_from_today.last.date)
+                     else
+                       next_weekday_of(today)
+                     end
+
+    order = Order.create!(date: new_order_date)
+    puts "#{order.date} の Order レコードが正常に作成されました"
+  end
+end

--- a/lib/tasks/order.rake
+++ b/lib/tasks/order.rake
@@ -3,7 +3,7 @@ require_relative './rake_helpers'
 namespace :order do
   desc '平日分の Order レコードを作成する'
   task create: :environment do
-    today = Time.current.beginning_of_day
+    today = Time.current.beginning_of_day.to_date
     orders_from_today = Order.where('date > ?', today)
 
     new_order_date = if orders_from_today.any?

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,8 +1,8 @@
 def next_weekday_of(date)
   next_date = date.tomorrow
   # NOTE: 平日とは、土・日・祝日いずれでもないものとする
-  return next_date unless HolidayJp.holiday?(next_date) \
-                            || next_date.sunday? \
-                            || next_date.saturday?
+  return next_date unless next_date.sunday? \
+                          || next_date.saturday? \
+                          || HolidayJp.holiday?(next_date)
   next_weekday_of(next_date)
 end

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,8 +1,11 @@
 def next_weekday_of(date)
   next_date = date.tomorrow
-  # NOTE: 平日とは、土・日・祝日いずれでもないものとする
-  return next_date if !next_date.sunday? \
-                      && !next_date.saturday? \
-                      && !HolidayJp.holiday?(next_date.to_date)
+  return next_date unless holiday?(next_date)
+
   next_weekday_of(next_date)
+end
+
+def holiday?(date)
+  # NOTE: 土日、もしくは国で定められた祝日であれば、平日扱いにはしたくない。
+  date.sunday? || date.saturday? || HolidayJp.holiday?(date.to_date)
 end

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,8 +1,8 @@
 def next_weekday_of(date)
   next_date = date.tomorrow
   # NOTE: 平日とは、土・日・祝日いずれでもないものとする
-  return next_date unless next_date.sunday? \
-                          || next_date.saturday? \
-                          || HolidayJp.holiday?(next_date.to_date)
+  return next_date if !next_date.sunday? \
+                      && !next_date.saturday? \
+                      && !HolidayJp.holiday?(next_date.to_date)
   next_weekday_of(next_date)
 end

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -3,6 +3,6 @@ def next_weekday_of(date)
   # NOTE: 平日とは、土・日・祝日いずれでもないものとする
   return next_date unless next_date.sunday? \
                           || next_date.saturday? \
-                          || HolidayJp.holiday?(next_date)
+                          || HolidayJp.holiday?(next_date.to_date)
   next_weekday_of(next_date)
 end

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -7,5 +7,5 @@ end
 
 def holiday?(date)
   # NOTE: 土日、もしくは国で定められた祝日であれば、平日扱いにはしたくない。
-  date.sunday? || date.saturday? || HolidayJp.holiday?(date.to_date)
+  date.sunday? || date.saturday? || HolidayJp.holiday?(date)
 end

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,0 +1,8 @@
+def next_weekday_of(date)
+  next_date = date.tomorrow
+  # NOTE: 平日とは、土・日・祝日いずれでもないものとする
+  return next_date unless HolidayJp.holiday?(next_date) \
+                            || next_date.sunday? \
+                            || next_date.saturday?
+  next_weekday_of(next_date)
+end


### PR DESCRIPTION
## できるようにすること

注文を取りまとめる、Order レコードを自動で作られるようにします。
Heroku Scheduler を使って任意の時刻（一日一度）になったらこの処理が実行されるようにします。

### どう動くか

日付が変わったら処理が実行されるようにする。
（トップページには平日（==営業日） 14 日分の日付が表示されていてほしいので、最初は 14 日間分の Order レコードが DB にあることを前提とする。）

~~その日の分の Order レコードを含めて数えて 14 こめの~~ 今 DB にあるすべての Order レコードを撮ってきて、そのうち最後の Order#date の値をみて、その翌日の値を持った Order レコードを作る。もしその日が土日か祝祭日なら、その日以降で一番近い平日の値の Order レコードを作る。

## TODO

- [x] `heroku config:add TZ='Asia/Tokyo'`（ステージング）
- [x] Rails 側のタイムゾーンを `Asia/Tokyo` にする
- [x] rake タスクを作る
- [ ] ~~トップページで表示するところの土日祝日を除く部分を消す~~ #58 でやる

## TODO after merged
- [ ] Heroku Scheduler にセットする（master にマージしたあとじゃないと確かめられないか）
- [ ] 正しく Order が作られたことを確認したいので、正常終了したら idobata に通知を送るような hook を設定したいかも。

## 考えてること

保存されるレコード数からして当分は大丈夫だと思うけど、過ぎた日の Order レコード（やそれに紐づく OrderItem レコード）は適宜消していったほうがいいんだろうな〜。原則として履歴をとっておく必要はないので...。
あとで考える？

## 対応 issue
#33