### PR TITLE
15 弁当の注文キャンセルをできるようにする。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 
 gem 'rails', '5.0.1'
 
+gem 'jquery-rails'
 gem 'holiday_jp'
 gem 'pg'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,10 @@ GEM
       activesupport (>= 4.1.0)
     holiday_jp (0.5.1)
     i18n (0.8.1)
+    jquery-rails (4.2.2)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -217,6 +221,7 @@ DEPENDENCIES
   factory_girl_rails
   ffaker
   holiday_jp
+  jquery-rails
   listen
   pg
   pry-byebug

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,3 @@
+//= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -33,6 +33,11 @@ class OrderItemsController < ApplicationController
 
   def destroy
     # 弁当注文削除
+    order_item = OrderItem.find(params[:id]).destroy
+    if order_item
+      notice = "#{order_item.customer_name}'s' #{order_item.lunchbox.name} item was successfully deleted."
+      redirect_to order_order_items_path(order_item.order) , notice: notice
+    end
   end
 
   def receive

--- a/app/views/order_items/index.html.slim
+++ b/app/views/order_items/index.html.slim
@@ -18,5 +18,5 @@ table(border=1)
             td.name(align="center") = "✓"
           - else
             td.name = ""
-
+        td.name = link_to "cancel", order_order_item_path(@order, item), method: :delete, data: {confirm: 'Are you certain you want to delete this?'}
 

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -11,7 +11,6 @@
 
 FactoryGirl.define do
   factory :lunchbox do
-    id 1
     name "normal"
     price 400
   end

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -11,6 +11,7 @@
 
 FactoryGirl.define do
   factory :lunchbox do
+    id 1
     name "normal"
     price 400
   end

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -14,6 +14,22 @@ RSpec.feature "Order::OrderItems", type: :feature do
     end
   end
 
+  feature '注文のキャンセル' do
+    scenario '注文者は自分の注文を確認できる' do
+      create(:lunchbox)
+      order = create(:order)
+      order_item = create(:order_item)
+
+      visit order_order_items_path(order)
+      expect(page).to have_text(order_item.customer_name)
+      expect(page).to have_text("cancel")
+
+      click_link('cancel')
+      expect(page).not_to have_text(order_item.customer_name)
+
+    end
+  end
+
 
 end
 

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Order::OrderItems", type: :feature do
   end
 
   feature '注文のキャンセル' do
-    scenario '注文者は自分の注文を確認できる' do
+    scenario '注文者は自分の注文をキャンセルできる' do
       create(:lunchbox)
       order = create(:order)
       order_item = create(:order_item)

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Order::OrderItems", type: :feature do
     scenario '注文者は自分の注文を確認できる' do
       lunchbox = create(:lunchbox)
       order = create(:order)
-
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
@@ -16,9 +15,9 @@ RSpec.feature "Order::OrderItems", type: :feature do
 
   feature '注文のキャンセル' do
     scenario '注文者は自分の注文をキャンセルできる' do
-      create(:lunchbox)
+      lunchbox = create(:lunchbox)
       order = create(:order)
-      order_item = create(:order_item)
+      order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)


### PR DESCRIPTION
#### 概要

~WIPは #45 がマージされたらはずします。~

~このPRにはテスト追加のためのコードとして #49 が含まれています。
よって、#49 がレビュー、マージされ次第WIPを外します。~

#49 がマージされたためWIPを外します。

注文の削除処理キャンセル機能を追加しました。

#### 実施事項

 - 以前削除した`jquery-rails` の復帰
    - これがないと REST の DELETE メソッドを`link_to`から呼び出せないため
 - `order_item`レコード削除処理の追加

#### 備考

削除時の`notice`に誰が、どの弁当を削除したかを保存してます。
削除後に`flash`メッセージとして出されば間違えて消した時に復帰できそうです。


