### PR TITLE
40 注文の編集機能の追加

### DIFF
--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -12,7 +12,6 @@ class OrderItemsController < ApplicationController
   def create
     @order = Order.find(params[:order_id])
     @order_item = @order.order_items.build(order_item_params)
-    @order_item.lunchbox_id = lunchbox_params[:id]
 
     if @order_item.save
       redirect_to order_order_items_path(@order) , notice: 'Order item was successfully created.'
@@ -30,7 +29,6 @@ class OrderItemsController < ApplicationController
   def update
     # 弁当注文編集
     @order_item = OrderItem.find(params[:id])
-    @order_item.lunchbox_id = lunchbox_params[:id]
     if @order_item.update(order_item_params)
       redirect_to order_order_items_path(@order_item.order)
     else
@@ -54,10 +52,7 @@ class OrderItemsController < ApplicationController
   private
 
   def order_item_params
-    params.require(:order_item).permit(:customer_name)
+    params.require(:order_item).permit(:customer_name, :lunchbox_id)
   end
 
-  def lunchbox_params
-    params.require(:lunchbox).permit(:id)
-  end
 end

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -1,9 +1,7 @@
 class OrderItemsController < ApplicationController
   def index
     # 予約確認・受取確認
-
     @order = Order.find(params["order_id"])
-
   end
 
   def new
@@ -25,10 +23,19 @@ class OrderItemsController < ApplicationController
 
   def edit
     # 弁当注文編集画面
+    @order = Order.find(params[:order_id])
+    @order_item = OrderItem.find(params[:id])
   end
 
   def update
     # 弁当注文編集
+    @order_item = OrderItem.find(params[:id])
+    @order_item.lunchbox_id = lunchbox_params[:id]
+    if @order_item.update(order_item_params)
+      redirect_to order_order_items_path(@order_item.order)
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/views/order_items/_form.html.slim
+++ b/app/views/order_items/_form.html.slim
@@ -10,8 +10,9 @@
             = message
   = f.label :customer_name
   = f.text_field :customer_name
-  = fields_for :lunchbox do |l|
-    = l.label :lunchbox
-    = l.select :id, Lunchbox.all.map{|l| [l.name, l.id] }
+
+  = f.label :lunchbox
+  = f.select :lunchbox_id, Lunchbox.all.map{|l| [l.name, l.id] }
+
   .actions
     = f.submit

--- a/app/views/order_items/index.html.slim
+++ b/app/views/order_items/index.html.slim
@@ -12,7 +12,7 @@ table(border=1)
 
     - @order.order_items.each do |item|
       tr
-        td.name = item.customer_name
+        td.name = link_to item.customer_name, edit_order_order_item_path(@order,item)
         - Lunchbox.all.each do |lunchbox|
           - if lunchbox.id == item.lunchbox_id
             td.name(align="center") = "✓"

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -14,4 +14,11 @@ FactoryGirl.define do
     name 'sample弁当'
     price 400
   end
+
+  factory :good_lunchbox, class: Lunchbox do
+    id 2
+    name "good"
+    price 400
+  end
+
 end

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -15,9 +15,4 @@ FactoryGirl.define do
     price 400
   end
 
-  factory :good_lunchbox, class: Lunchbox do
-    name "sample弁当-上"
-    price 400
-  end
-
 end

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -16,8 +16,7 @@ FactoryGirl.define do
   end
 
   factory :good_lunchbox, class: Lunchbox do
-    id 2
-    name "good"
+    name "sample弁当-上"
     price 400
   end
 

--- a/spec/features/order.rb
+++ b/spec/features/order.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Order::OrderItems', type: :feature do
+RSpec.feature 'Order', type: :feature do
 
   feature '注文の確認' do
     scenario '注文者は自分の注文を確認できる' do
@@ -44,14 +44,11 @@ RSpec.feature 'Order::OrderItems', type: :feature do
 
       # edit name
       click_link(order_item.customer_name)
-      expect(find_field('Customer name').value).to eq order_item.customer_name
       fill_in 'Customer name', with: new_name
 
       # change lunchbox
       expect(page).to have_select('order_item[lunchbox_id]',selected: 'sample弁当')
       select new_lunchbox_name, from: 'order_item[lunchbox_id]'
-
-      # text(order_item.customer_name)
 
       # update confirm
       click_button 'Update Order item'

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -30,6 +30,28 @@ RSpec.feature "Order::OrderItems", type: :feature do
   end
 
 
+  feature '注文の修正' do
+    scenario '注文者は自分の注文を修正できる' do
+      create(:lunchbox)
+      order = create(:order)
+      order_item = create(:order_item)
+
+      visit order_order_items_path(order)
+      expect(page).to have_text(order_item.customer_name)
+
+      # edit name
+      click_link(order_item.customer_name)
+      expect(page).not_to have_text(order_item.customer_name)
+      fill_in "Customer name", with:"another_name"
+
+      # update confirm
+      click_button "Update Order item"
+      expect(page).not_to have_text(order_item.customer_name)
+      expect(page).to have_text("another_name")
+
+    end
+  end
+
 end
 
 

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -33,21 +33,34 @@ RSpec.feature "Order::OrderItems", type: :feature do
   feature '注文の修正' do
     scenario '注文者は自分の注文を修正できる' do
       create(:lunchbox)
+      create(:good_lunchbox)
       order = create(:order)
       order_item = create(:order_item)
+      new_name = "another_name"
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
 
       # edit name
       click_link(order_item.customer_name)
-      expect(page).not_to have_text(order_item.customer_name)
-      fill_in "Customer name", with:"another_name"
+      expect(find_field('Customer name').value).to eq order_item.customer_name
+      fill_in "Customer name", with:new_name
+
+      # change lunchbox
+      expect(page).to have_select("order_item[lunchbox_id]",selected: "normal")
+      select "good", from: "order_item[lunchbox_id]"
+
+      # text(order_item.customer_name)
 
       # update confirm
       click_button "Update Order item"
       expect(page).not_to have_text(order_item.customer_name)
-      expect(page).to have_text("another_name")
+      expect(page).not_to have_text("hoge")
+      expect(page).to have_text(new_name)
+
+      # confirm new order in edit page
+      click_link(new_name)
+      expect(page).to have_select("order_item[lunchbox_id]",selected: "good")
 
     end
   end

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Order::OrderItems", type: :feature do
   feature '注文の修正' do
     scenario '注文者は自分の注文を修正できる' do
       lunchbox = create(:lunchbox)
-      create(:good_lunchbox)
+      create(:lunchbox, name: 'sample弁当-上')
       order = create(:order)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
       new_name = "another_name"

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Order::OrderItems", type: :feature do
+RSpec.feature 'Order::OrderItems', type: :feature do
 
   feature '注文の確認' do
     scenario '注文者は自分の注文を確認できる' do
@@ -21,7 +21,7 @@ RSpec.feature "Order::OrderItems", type: :feature do
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
-      expect(page).to have_text("cancel")
+      expect(page).to have_text('cancel')
 
       click_link('cancel')
       expect(page).not_to have_text(order_item.customer_name)
@@ -36,9 +36,8 @@ RSpec.feature "Order::OrderItems", type: :feature do
       create(:lunchbox, name: 'sample弁当-上')
       order = create(:order)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
-      new_name = "another_name"
-      new_lunchbox_name = "sample弁当-上"
-
+      new_name = 'another_name'
+      new_lunchbox_name = 'sample弁当-上'
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
@@ -46,22 +45,22 @@ RSpec.feature "Order::OrderItems", type: :feature do
       # edit name
       click_link(order_item.customer_name)
       expect(find_field('Customer name').value).to eq order_item.customer_name
-      fill_in "Customer name", with:new_name
+      fill_in 'Customer name', with: new_name
 
       # change lunchbox
-      expect(page).to have_select("order_item[lunchbox_id]",selected: "sample弁当")
-      select new_lunchbox_name, from: "order_item[lunchbox_id]"
+      expect(page).to have_select('order_item[lunchbox_id]',selected: 'sample弁当')
+      select new_lunchbox_name, from: 'order_item[lunchbox_id]'
 
       # text(order_item.customer_name)
 
       # update confirm
-      click_button "Update Order item"
+      click_button 'Update Order item'
       expect(page).not_to have_text(order_item.customer_name)
       expect(page).to have_text(new_name)
 
       # confirm new order in edit page
       click_link(new_name)
-      expect(page).to have_select("order_item[lunchbox_id]",selected: new_lunchbox_name)
+      expect(page).to have_select('order_item[lunchbox_id]',selected: new_lunchbox_name)
 
     end
   end

--- a/spec/features/order/order_order_items_spec.rb
+++ b/spec/features/order/order_order_items_spec.rb
@@ -32,11 +32,13 @@ RSpec.feature "Order::OrderItems", type: :feature do
 
   feature '注文の修正' do
     scenario '注文者は自分の注文を修正できる' do
-      create(:lunchbox)
+      lunchbox = create(:lunchbox)
       create(:good_lunchbox)
       order = create(:order)
-      order_item = create(:order_item)
+      order_item = create(:order_item, order: order, lunchbox: lunchbox)
       new_name = "another_name"
+      new_lunchbox_name = "sample弁当-上"
+
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
@@ -47,20 +49,19 @@ RSpec.feature "Order::OrderItems", type: :feature do
       fill_in "Customer name", with:new_name
 
       # change lunchbox
-      expect(page).to have_select("order_item[lunchbox_id]",selected: "normal")
-      select "good", from: "order_item[lunchbox_id]"
+      expect(page).to have_select("order_item[lunchbox_id]",selected: "sample弁当")
+      select new_lunchbox_name, from: "order_item[lunchbox_id]"
 
       # text(order_item.customer_name)
 
       # update confirm
       click_button "Update Order item"
       expect(page).not_to have_text(order_item.customer_name)
-      expect(page).not_to have_text("hoge")
       expect(page).to have_text(new_name)
 
       # confirm new order in edit page
       click_link(new_name)
-      expect(page).to have_select("order_item[lunchbox_id]",selected: "good")
+      expect(page).to have_select("order_item[lunchbox_id]",selected: new_lunchbox_name)
 
     end
   end


### PR DESCRIPTION
#### 概要

一度行った注文の編集を行えるようにしました。

~このPRにはテスト追加のためのコードとして #49 及び #46  が含まれています。
よって、#49 #46 がマージされ次第WIPを外します。~
#49 #46 がマージされたのでWIPを外しました。
同時にコンフリクトの解決も実行。
いつでもレビューできます。

#### 実施事項

`order_item`に対して`edit`アクションを追加。

#### 備考

特になし

