### PR TITLE
受け取り機能

### DIFF
--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -4,7 +4,7 @@ class OrderItemsController < ApplicationController
   before_action :set_order_item, only: %i(edit update destroy receive)
 
   def index
-    if @order.closed_at?
+    if @order.closed?
       render 'receive'
     else
       render 'index'

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -2,6 +2,12 @@ class OrderItemsController < ApplicationController
   def index
     # 予約確認・受取確認
     @order = Order.find(params["order_id"])
+
+    if @order.closed_at?
+      render 'receive'
+    else
+      render 'index'
+    end
   end
 
   def new

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -1,4 +1,6 @@
 class OrderItemsController < ApplicationController
+  before_action :set_order_item, only: %i(edit update destroy receive)
+
   def index
     # 予約確認・受取確認
     @order = Order.find(params["order_id"])
@@ -29,12 +31,9 @@ class OrderItemsController < ApplicationController
   def edit
     # 弁当注文編集画面
     @order = Order.find(params[:order_id])
-    @order_item = OrderItem.find(params[:id])
   end
 
   def update
-    # 弁当注文編集
-    @order_item = OrderItem.find(params[:id])
     if @order_item.update(order_item_params)
       redirect_to order_order_items_path(@order_item.order)
     else
@@ -44,18 +43,26 @@ class OrderItemsController < ApplicationController
 
   def destroy
     # 弁当注文削除
-    order_item = OrderItem.find(params[:id]).destroy
-    if order_item
-      notice = "#{order_item.customer_name}'s' #{order_item.lunchbox.name} item was successfully deleted."
-      redirect_to order_order_items_path(order_item.order) , notice: notice
+    @order_item.destroy
+    if @order_item
+      notice = "#{@order_item.customer_name}'s' #{@order_item.lunchbox.name} item was successfully deleted."
+      redirect_to order_order_items_path(@order_item.order) , notice: notice
     end
   end
 
   def receive
-    # 注文を受け取る
+    if @order_item.update(received_at: Time.current)
+      redirect_to order_order_items_path(@order_item.order) , notice: '注文した弁当を受け取りました'
+    else
+      redirect_to order_order_items_path(@order_item.order) , alert: '予期せぬエラーが発生しました'
+    end
   end
 
   private
+
+  def set_order_item
+    @order_item = OrderItem.find(params[:id])
+  end
 
   def order_item_params
     params.require(:order_item).permit(:customer_name, :lunchbox_id)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -23,4 +23,8 @@ class Order < ApplicationRecord
       orders.reject {|o| HolidayJp.holiday?(o.date) || o.date.wday == 6 || o.date.wday == 0 }
     end
   end
+
+  def closed?
+    closed_at?
+  end
 end

--- a/app/views/order_items/receive.html.slim
+++ b/app/views/order_items/receive.html.slim
@@ -1,18 +1,22 @@
 h1 受取確認
 
-/table(border=1)
-/  tr
-/    td.name(align="center") = "-"
-/    - Lunchbox.all.each do |lunchbox|
-/      td.name = lunchbox.name + "(#{lunchbox.price.to_s}円)"
-/    td.name = "-"
-/
-/    - @order.order_items.each do |item|
-/      tr
-/        td.name = link_to item.customer_name, edit_order_order_item_path(@order,item)
-/        - Lunchbox.all.each do |lunchbox|
-/          - if lunchbox.id == item.lunchbox_id
-/            td.name(align="center") = "✓"
-/          - else
-/            td.name = ""
-/        td.name = link_to "cancel", order_order_item_path(@order, item), method: :delete, data: {confirm: 'Are you certain you want to delete this?'}
+table(border=1)
+  tr
+    td.name(align="center") = "-"
+    - Lunchbox.all.each do |lunchbox|
+      td.name = lunchbox.name + "(#{lunchbox.price.to_s}円)"
+    td.name = "-"
+
+    - @order.order_items.each do |item|
+      tr
+        td.name = item.customer_name
+        - Lunchbox.all.each do |lunchbox|
+          - if lunchbox.id == item.lunchbox_id
+            td.name(align="center") = "✓"
+          - else
+            td.name = ""
+        td.name
+          - if item.received_at?
+            = '受け取り済'
+          - else
+            = link_to '受け取る', receive_order_order_item_path(@order, item), method: :patch

--- a/app/views/order_items/receive.html.slim
+++ b/app/views/order_items/receive.html.slim
@@ -1,0 +1,18 @@
+h1 受取確認
+
+/table(border=1)
+/  tr
+/    td.name(align="center") = "-"
+/    - Lunchbox.all.each do |lunchbox|
+/      td.name = lunchbox.name + "(#{lunchbox.price.to_s}円)"
+/    td.name = "-"
+/
+/    - @order.order_items.each do |item|
+/      tr
+/        td.name = link_to item.customer_name, edit_order_order_item_path(@order,item)
+/        - Lunchbox.all.each do |lunchbox|
+/          - if lunchbox.id == item.lunchbox_id
+/            td.name(align="center") = "✓"
+/          - else
+/            td.name = ""
+/        td.name = link_to "cancel", order_order_item_path(@order, item), method: :delete, data: {confirm: 'Are you certain you want to delete this?'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
 
   resources :orders, only: %i(index) do
     resources :order_items, except: %i(show) do
-      patch :receive
+      member do
+        patch :receive
+      end
     end
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -12,5 +12,9 @@
 FactoryGirl.define do
   factory :order do
     date Time.zone.local(2017, 2, 1)
+
+    trait :closed do
+      closed_at Time.zone.local(2017, 2, 1, 9, 20)
+    end
   end
 end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Order', type: :feature do
-  given(:lunchbox) { create(:lunchbox) }
+  given!(:lunchbox) { create(:lunchbox) }
   given(:order) { create(:order) }
 
   feature '注文の確認' do
@@ -11,6 +11,40 @@ RSpec.feature 'Order', type: :feature do
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
       expect(page).to have_text('予約確認・注文確認')
+    end
+  end
+
+  feature '注文の新規作成' do
+    scenario 'Order が締め切られている場合、注文者は新しく注文できない' do
+      order = create(:order, :closed)
+      visit new_order_order_item_path(order)
+
+      # 受取確認に戻される
+      expect(page).to have_text('受取確認')
+    end
+
+    scenario 'Order が締め切られている場合、注文者は新しい注文を確定できない' do
+      visit order_order_items_path(order)
+      user_name = 'sample-user'
+
+      # 未予約なことを確認
+      expect(page).not_to have_text(user_name)
+
+      # 予約ページで情報を入力
+      click_link('予約する')
+      fill_in 'Customer name', with: 'customer'
+      select lunchbox.name, from: 'order_item[lunchbox_id]'
+
+      # 弁当発注の確定
+      order.closed_at = Time.zone.local(2017, 2, 1)
+      order.save
+
+      # ユーザーが自分の注文を確定しようとする
+      click_button 'Create Order item'
+
+      # 受取確認に戻され、予約は確定できていない
+      expect(page).not_to have_text(user_name)
+      expect(page).to have_text('受取確認')
     end
   end
 
@@ -24,7 +58,16 @@ RSpec.feature 'Order', type: :feature do
 
       click_link('cancel')
       expect(page).not_to have_text(order_item.customer_name)
+    end
 
+    scenario 'Order が締め切られている場合、注文者は自分の注文をキャンセルできない' do
+      order = create(:order, :closed)
+      order_item = create(:order_item, order: order, lunchbox: lunchbox)
+
+      visit order_order_items_path(order)
+
+      expect(page).to have_text(order_item.customer_name)
+      expect(page).not_to have_link('cancel')
     end
   end
 
@@ -54,6 +97,15 @@ RSpec.feature 'Order', type: :feature do
       # confirm new order in edit page
       click_link(new_name)
       expect(page).to have_select('order_item[lunchbox_id]',selected: new_lunchbox_name)
+    end
+
+    scenario 'Order が締め切られている場合、注文者は自分の注文を編集できない' do
+      order = create(:order, :closed)
+      order_item = create(:order_item, order: order, lunchbox: lunchbox)
+
+      visit order_order_items_path(order)
+
+      expect(page).not_to have_link(order_item.customer_name)
     end
   end
 

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -19,7 +19,6 @@ RSpec.feature 'Order', type: :feature do
       order = create(:order, :closed)
       visit new_order_order_item_path(order)
 
-      # 受取確認に戻される
       expect(page).to have_text('受取確認')
     end
 
@@ -27,22 +26,18 @@ RSpec.feature 'Order', type: :feature do
       visit order_order_items_path(order)
       user_name = 'sample-user'
 
-      # 未予約なことを確認
+      # NOTE: 未予約なことを確認
       expect(page).not_to have_text(user_name)
 
-      # 予約ページで情報を入力
       click_link('予約する')
       fill_in 'Customer name', with: 'customer'
       select lunchbox.name, from: 'order_item[lunchbox_id]'
 
-      # 弁当発注の確定
-      order.closed_at = Time.zone.local(2017, 2, 1)
-      order.save
+      # NOTE: 注文の閉め
+      order.update(closed_at: Time.zone.local(2017, 2, 1))
 
-      # ユーザーが自分の注文を確定しようとする
       click_button 'Create Order item'
 
-      # 受取確認に戻され、予約は確定できていない
       expect(page).not_to have_text(user_name)
       expect(page).to have_text('受取確認')
     end
@@ -81,20 +76,16 @@ RSpec.feature 'Order', type: :feature do
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
 
-      # edit name
       click_link(order_item.customer_name)
       fill_in 'Customer name', with: new_name
 
-      # change lunchbox
       expect(page).to have_select('order_item[lunchbox_id]',selected: lunchbox.name)
       select new_lunchbox_name, from: 'order_item[lunchbox_id]'
 
-      # update confirm
       click_button 'Update Order item'
       expect(page).not_to have_text(order_item.customer_name)
       expect(page).to have_text(new_name)
 
-      # confirm new order in edit page
       click_link(new_name)
       expect(page).to have_select('order_item[lunchbox_id]',selected: new_lunchbox_name)
     end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -65,6 +65,10 @@ RSpec.feature 'Order', type: :feature do
 
       visit order_order_items_path(order)
       expect(page).to have_text('受取確認')
+
+      click_link '受け取る'
+
+      expect(page).to have_text('受け取り済')
     end
   end
 end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -1,22 +1,21 @@
 require 'rails_helper'
 
 RSpec.feature 'Order', type: :feature do
+  given(:lunchbox) { create(:lunchbox) }
+  given(:order) { create(:order) }
 
   feature '注文の確認' do
     scenario '注文者は自分の注文を確認できる' do
-      lunchbox = create(:lunchbox)
-      order = create(:order)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
+      expect(page).to have_text('予約確認・注文確認')
     end
   end
 
   feature '注文のキャンセル' do
     scenario '注文者は自分の注文をキャンセルできる' do
-      lunchbox = create(:lunchbox)
-      order = create(:order)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
@@ -29,12 +28,9 @@ RSpec.feature 'Order', type: :feature do
     end
   end
 
-
   feature '注文の修正' do
     scenario '注文者は自分の注文を修正できる' do
-      lunchbox = create(:lunchbox)
       create(:lunchbox, name: 'sample弁当-上')
-      order = create(:order)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
       new_name = 'another_name'
       new_lunchbox_name = 'sample弁当-上'
@@ -47,7 +43,7 @@ RSpec.feature 'Order', type: :feature do
       fill_in 'Customer name', with: new_name
 
       # change lunchbox
-      expect(page).to have_select('order_item[lunchbox_id]',selected: 'sample弁当')
+      expect(page).to have_select('order_item[lunchbox_id]',selected: lunchbox.name)
       select new_lunchbox_name, from: 'order_item[lunchbox_id]'
 
       # update confirm
@@ -58,10 +54,17 @@ RSpec.feature 'Order', type: :feature do
       # confirm new order in edit page
       click_link(new_name)
       expect(page).to have_select('order_item[lunchbox_id]',selected: new_lunchbox_name)
-
     end
   end
 
+  feature '注文の受取' do
+    given(:order) { create(:order, :closed) }
+
+    scenario '注文者は自分の注文した弁当を受け取ったことをシステムに知らせることが出来る' do
+      order_items = create(:order_item, order: order, lunchbox: lunchbox)
+
+      visit order_order_items_path(order)
+      expect(page).to have_text('受取確認')
+    end
+  end
 end
-
-


### PR DESCRIPTION
#14 の対応

![2017-03-21 19 39 03](https://cloud.githubusercontent.com/assets/3395349/24143764/14a2fd4a-0e6e-11e7-9fc3-705c88b36a5f.png)

## 備考

受け取りの取り消しなのですが、ここでは実装してません。
受け取りの取り消しはリリースしてからでもいいのかなーと思ってきたためです。間違って受け取りボタンを押す事案がそんな頻繁に起こるのかちょっと疑問に感じてます。