### PR TITLE
トップページの表示を修正

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,5 @@
 class OrdersController < ApplicationController
   def index
-    @orders = Order.where('date > ?', Time.current).limit(Order::SHOW_COUNT).order(date: :asc)
+    @orders = Order.available
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < ApplicationController
   def index
-    @today_order = Order.find_by(date: Time.current)
+    @today_order = Order.find_by(date: Time.current.to_date)
     @orders = Order.available
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,5 @@
 class OrdersController < ApplicationController
   def index
-    @orders = Order.on_weekday
+    @orders = Order.where('date > ?', Time.current).limit(Order::SHOW_COUNT).order(date: :asc)
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,6 @@
 class OrdersController < ApplicationController
   def index
+    @today_order = Order.find_by(date: Time.current)
     @orders = Order.available
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,7 +15,7 @@ class Order < ApplicationRecord
   has_many :order_items
 
   scope :available, -> {
-    where('date > ?', Time.current) \
+    where('date >= ?', Time.current) \
       .limit(Order::SHOW_COUNT) \
       .order(date: :asc) \
       .reject(&:closed?)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,7 +16,7 @@ class Order < ApplicationRecord
 
   scope :available, -> {
     where('date >= ?', Time.current) \
-      .limit(Order::SHOW_COUNT) \
+      .limit(SHOW_COUNT) \
       .order(date: :asc) \
       .reject(&:closed?)
   }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,10 +10,16 @@
 #
 
 class Order < ApplicationRecord
-  has_many :order_items
   SHOW_COUNT = 10
 
+  has_many :order_items
 
+  scope :available, -> {
+    where('date > ?', Time.current) \
+      .limit(Order::SHOW_COUNT) \
+      .order(date: :asc) \
+      .reject(&:closed?)
+  }
 
   def close(close_time = Time.current)
     update(closed_at: close_time)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,18 +11,9 @@
 
 class Order < ApplicationRecord
   has_many :order_items
+  SHOW_COUNT = 10
 
-  class << self
-    # NOTE 操作しているその日から14日後までのうちの出社日（祝祭日・土日以外）を返す。
-    #      年末年始休暇などは毎年違うので、時期が近くなったら適宜対応すること。
-    def on_weekday
-      start_date = Time.current
-      end_date = Time.current.since(14.days)
-      orders = Order.where(date: start_date..end_date)
 
-      orders.reject {|o| HolidayJp.holiday?(o.date) || o.date.wday == 6 || o.date.wday == 0 }
-    end
-  end
 
   def close(close_time = Time.current)
     update(closed_at: close_time)

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -1,9 +1,17 @@
-h1
-  | 注文日選択
+- if @today_order&.closed?
+  h2
+    | 本日 (#{@today_order.date}) のお弁当を受け取る
+  -# TODO インタフェースとしてはイケてないけどとりあえずやりたいことはこういうこと
+  p
+    | 本日の注文は締め切りました。受け取りチェックをするには以下のリンクをクリックしてください。
+  = link_to @today_order.date, order_order_items_path(@today_order)
+
+h2
+  | お弁当を注文する
 
 - if @orders.any?
   p
-    | お弁当を注文したい日付を選んでください。
+    | 注文したい日付を選んでください。
   - @orders.each do |order|
     ul
       li= link_to order.date, order_order_items_path(order)

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -1,7 +1,12 @@
 h1
   | 注文日選択
-p
-  | お弁当を注文したい日付を選んでください。
-- @orders.each do |order|
-  ul
-    li= link_to order.date, order_order_items_path(order)
+
+- if @orders.any?
+  p
+    | お弁当を注文したい日付を選んでください。
+  - @orders.each do |order|
+    ul
+      li= link_to order.date, order_order_items_path(order)
+- else
+  p
+    | 注文できる日がありません。管理者にお問い合わせください。


### PR DESCRIPTION
## できるようにしたこと

- トップページに並ぶ日付を昇順にします。via #58 
- 注文を締め切った注文日はトップページに表示させないようにします。via #63
