### PR TITLE
basic認証の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'seed-fu'
 gem 'slim-rails'
 
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'bullet'
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,10 @@ GEM
     concurrent-ruby (1.0.5)
     database_rewinder (0.8.0)
     diff-lcs (1.3)
+    dotenv (2.2.0)
+    dotenv-rails (2.2.0)
+      dotenv (= 2.2.0)
+      railties (>= 3.2, < 5.1)
     erubis (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -218,6 +222,7 @@ DEPENDENCIES
   bullet
   capybara
   database_rewinder
+  dotenv-rails
   factory_girl_rails
   ffaker
   holiday_jp

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,3 +1,10 @@
 class Admin::ApplicationController < ApplicationController
 
+  private
+
+  def basic_authorization
+    authenticate_or_request_with_http_basic do |user, pass|
+      user == ENV['ADMIN_ID'] && pass == ENV['ADMIN_PASS']
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,14 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :basic_authorization
+
+  private
+
+  def basic_authorization
+    authenticate_or_request_with_http_basic do |user, pass|
+      user == ENV['USER_ID'] && pass == ENV['USER_PASS']
+    end
+  end
+
 end

--- a/spec/features/admin_orders_spec.rb
+++ b/spec/features/admin_orders_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin::Orders', type: :feature do
+
+  include BasicAuthHelper
+  before :each do
+    admin_login
+  end
+
   feature '管理者機能' do
     given!(:order) { create(:order) }
 

--- a/spec/features/admin_orders_spec.rb
+++ b/spec/features/admin_orders_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'Admin::Orders', type: :feature do
 
-  include BasicAuthHelper
   before :each do
     admin_login
   end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Order', type: :feature do
   given!(:lunchbox) { create(:lunchbox) }
   given(:order) { create(:order) }
 
-  include BasicAuthHelper
   before :each do
     user_login
   end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -4,6 +4,11 @@ RSpec.feature 'Order', type: :feature do
   given!(:lunchbox) { create(:lunchbox) }
   given(:order) { create(:order) }
 
+  include BasicAuthHelper
+  before :each do
+    user_login
+  end
+
   feature '注文の確認' do
     scenario '注文者は自分の注文を確認できる' do
       order_item = create(:order_item, order: order, lunchbox: lunchbox)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include BasicAuthHelper
 end

--- a/spec/support/basic_auth_helper.rb
+++ b/spec/support/basic_auth_helper.rb
@@ -1,0 +1,21 @@
+module BasicAuthHelper
+
+  def user_login
+    user_name = ENV['USER_ID']
+    password = ENV['USER_PASS']
+
+    basic = ActionController::HttpAuthentication::Basic
+    credentials = basic.encode_credentials(user_name, password)
+    page.driver.header('Authorization', credentials)
+  end
+
+  def admin_login
+    user_name = ENV['ADMIN_ID']
+    password = ENV['ADMIN_PASS']
+
+    basic = ActionController::HttpAuthentication::Basic
+    credentials = basic.encode_credentials(user_name, password)
+    page.driver.header('Authorization', credentials)
+  end
+
+end


### PR DESCRIPTION
#### 概要

#41 の対応です。

#### 実施事項

 - ユーザー用のBASIC認証を追加
 - 管理者用のBASIC認証を追加
 - BASIC認証をパスするようにテスト用ヘルパを追加
    - それに伴うテスト修正

#### 備考

BASIC認証のためのID,パスワードは環境変数に格納するようにしています。
開発、及びテスト用に`.env`ファイルをプロジェクトのルートに置いてください。
dotenvの[README](https://github.com/bkeepers/dotenv#should-i-commit-my-env-file)に従って`.env`ファイルはコミット対象から外しています。

Herokuでのデプロイ時は下記環境変数の追加をお願いします。
```
USER_ID
USER_PASS
ADMIN_ID
ADMIN_PASS
```

そもそも環境変数に置くべきでないなどあれば指摘をお願い致します

