### PR TITLE
69 注文者の名前が空なら注文できなくさせる

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -16,4 +16,6 @@ class OrderItem < ApplicationRecord
   #     やりたいことを実現するには belongs_to lunchbox にするしかない。
   belongs_to :lunchbox
   belongs_to :order
+
+  validates :customer_name, presence: true
 end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -19,6 +19,17 @@ RSpec.feature 'Order', type: :feature do
   end
 
   feature '注文の新規作成' do
+
+    scenario '注文者は注文者名を空のまま注文を追加できない' do
+      user_name = ''
+      visit new_order_order_item_path(order)
+      fill_in 'Customer name', with: user_name
+      select lunchbox.name, from: 'order_item[lunchbox_id]'
+      click_button 'Create Order item'
+
+      expect(page).to have_text("New Order Item")
+    end
+
     scenario 'Order が締め切られている場合、注文者は新しく注文できない' do
       order = create(:order, :closed)
       visit new_order_order_item_path(order)

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -19,17 +19,6 @@ RSpec.feature 'Order', type: :feature do
   end
 
   feature '注文の新規作成' do
-
-    scenario '注文者は注文者名を空のまま注文を追加できない' do
-      user_name = ''
-      visit new_order_order_item_path(order)
-      fill_in 'Customer name', with: user_name
-      select lunchbox.name, from: 'order_item[lunchbox_id]'
-      click_button 'Create Order item'
-
-      expect(page).to have_text("New Order Item")
-    end
-
     scenario 'Order が締め切られている場合、注文者は新しく注文できない' do
       order = create(:order, :closed)
       visit new_order_order_item_path(order)


### PR DESCRIPTION
#### 概要
#69 の対応です。

#### 実施事項
 - `validation`の追加
 - 上記の`validation`を検証するようなテストの追加

#### 備考
他に優先度の高いカード( #68 )があったのですが、そちらは他のPRがマージされないと着手できないため、こちらを優先しました。
