### PR TITLE
turbolinksを復活させた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'puma'
 gem 'sass-rails'
 gem 'seed-fu'
 gem 'slim-rails'
+gem 'turbolinks'
 
 group :development, :test do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,9 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.6)
     timecop (0.8.1)
+    turbolinks (5.0.1)
+      turbolinks-source (~> 5)
+    turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
@@ -248,6 +251,7 @@ DEPENDENCIES
   slim-rails
   slim_lint
   timecop
+  turbolinks
 
 BUNDLED WITH
    1.14.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets
+//= require turbolinks

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,8 +3,8 @@ html
   head
     title Bento
     meta name="viewport" content="width=device-width, initial-scale=1.0"
-    = stylesheet_link_tag    "application", media: 'all', 'data-turbolinks-track' => true
-    = javascript_include_tag "application", 'data-turbolinks-track' => true
+    = stylesheet_link_tag    "application", media: 'all', 'data-turbolinks-track' => 'reload'
+    = javascript_include_tag "application", 'data-turbolinks-track' => 'reload'
     = csrf_meta_tags
 
   body


### PR DESCRIPTION
ユーザの使い勝手を考えた時、毎回画面遷移する度に画面を再描画させるのはあまり良くないと考えます。スマートフォンでも使うユーザが出てくることが想定されているこのサービスではなおさらです。
そこで、リンクでの画面遷移の時だけbody部分だけ書き換えるようにするturbolinksを復活させたいです。
turbolinksを使うと、`$(document).ready` や `window.onload` のような画面が描画された時に発火されるJSが動かなくなりますが、現在使っていないので問題ないと考えてます。