### PR TITLE
こわれたテストを直した

### DIFF
--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Order', type: :feature do
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
-      expect(page).to have_text('予約確認・注文確認')
+      expect(page).to have_text('2017/02/01の注文一覧')
     end
   end
 


### PR DESCRIPTION
# やったこと

https://github.com/colorbox/bento/pull/71 ここでページの `h1` に出す文言を変えているのですが、テストのなかで Capybara を使って確認している箇所があっておらずテストが落ちるようになっていたので、なおしました。