### PR TITLE
日付を表示しているところは、曜日も一緒に表示されるようにした

### DIFF
--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -4,7 +4,7 @@
   -# TODO インタフェースとしてはイケてないけどとりあえずやりたいことはこういうこと
   p
     | 本日の注文は締め切りました。受け取りチェックをするには以下のリンクをクリックしてください。
-  = link_to @today_order.date, order_order_items_path(@today_order)
+  = link_to l(@today_order.date), order_order_items_path(@today_order)
 
 h2
   | お弁当を注文する
@@ -14,7 +14,7 @@ h2
     | 注文したい日付を選んでください。
   - @orders.each do |order|
     ul
-      li= link_to order.date, order_order_items_path(order)
+      li= link_to l(order.date), order_order_items_path(order)
 - else
   p
     | 注文できる日がありません。管理者にお問い合わせください。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,8 +4,16 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
   date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
     formats:
-      default: "%Y/%m/%d"
+      default: "%Y/%m/%d(%a)"
   errors:
     format: "%{attribute}%{message}"
     messages:

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Order', type: :feature do
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
-      expect(page).to have_text('2017/02/01の注文一覧')
+      expect(page).to have_text('2017/02/01(水)の注文一覧')
     end
   end
 


### PR DESCRIPTION
## やったこと

日付につづいて曜日も表示されるようにしました。

`I18n.l` で出すにあたって必要だったデータは https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml からコピーしてきています。

## 対応 issue
#81 

## スクリーンショット

<img width="822" alt="bento" src="https://cloud.githubusercontent.com/assets/1979779/24332618/d2bf99b8-1284-11e7-8fdb-9e788fee6b8f.png">

<img width="558" alt="bento" src="https://cloud.githubusercontent.com/assets/1979779/24332621/e220fc62-1284-11e7-9bfa-8977b9b35c8f.png">
