### PR TITLE
Heroku で動かすにあたって Ruby のバージョンを指定した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.4.0'
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"


### PR DESCRIPTION
## やったこと

使う Ruby のバージョンをGemfile で明示的に指定しました。
バージョンは 3 月 1 日のミーティングで決めていたとおり、 2.4.0 です。

## なぜやったか
Heroku は、Gemfile 内で Ruby のバージョンが指定されていない場合は Ruby 2.2.4 を使います。
https://devcenter.heroku.com/articles/ruby-versions
しかしトップページでは 2.3.0 から入った機能である lonely operator `&.` を使っており、ここでエラーになってしまうため、バージョン指定を入れました。


