### PR TITLE
Order レコードが作成されたときに idobata に通知する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 gem 'rails', '5.0.1'
 
 gem 'bootstrap-sass'
+gem 'faraday'
 gem 'holiday_jp'
 gem 'jquery-rails'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
     ffaker (2.5.0)
     ffi (1.9.18)
     globalid (0.3.7)
@@ -101,6 +103,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multipart-post (2.0.0)
     nio4r (1.2.1)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
@@ -235,6 +238,7 @@ DEPENDENCIES
   database_rewinder
   dotenv-rails
   factory_girl_rails
+  faraday
   ffaker
   holiday_jp
   jquery-rails
@@ -253,5 +257,9 @@ DEPENDENCIES
   slim_lint
   timecop
   turbolinks
+
+RUBY VERSION
+   ruby 2.4.0p0
+
 BUNDLED WITH
    1.14.6

--- a/lib/idobata.rb
+++ b/lib/idobata.rb
@@ -1,0 +1,8 @@
+module Idobata
+  def post(message)
+    url = ENV['IDOBATA_HOOK_URL']
+    Faraday.post(url, source: message, format: 'html') if url.present?
+  end
+
+  module_function :post
+end

--- a/lib/tasks/order.rake
+++ b/lib/tasks/order.rake
@@ -1,8 +1,11 @@
 require_relative './rake_helpers'
+require_relative '../idobata'
 
 namespace :order do
   desc '平日分の Order レコードを作成する'
   task create: :environment do
+    include Idobata
+
     today = Time.current.beginning_of_day.to_date
     orders_from_today = Order.where('date > ?', today)
 
@@ -12,7 +15,9 @@ namespace :order do
                        next_weekday_of(today)
                      end
 
-    order = Order.create!(date: new_order_date)
-    puts "#{order.date} の Order レコードが正常に作成されました"
+    Order.transaction do
+      order = Order.create!(date: new_order_date)
+      Idobata.post "#{I18n.l(order.date)} の Order レコードが正常に作成されました"
+    end
   end
 end

--- a/lib/tasks/order.rake
+++ b/lib/tasks/order.rake
@@ -15,9 +15,11 @@ namespace :order do
                        next_weekday_of(today)
                      end
 
-    Order.transaction do
+    begin
       order = Order.create!(date: new_order_date)
       Idobata.post "#{I18n.l(order.date)} の Order レコードが正常に作成されました"
+    rescue => e
+      Idobata.post e.message
     end
   end
 end


### PR DESCRIPTION
## できるようにしたこと

Order レコードを Heroku Scheduler に設定して一日一度自動的に動くようにしていますが（ステージングも本番も既に設定済み）、これが正常に動いているか心配になるときがあるので、Order レコードが作成されたら idobata に通知するようにしました。

通知する先のチャンネルは今のところ bento 開発者 room でいいと思っていますが、他に専用 room を作ったほうがいいのでは等のご意見があればきかせてください。

## 必要な準備

- 環境変数に `IDOBATA_HOOK_URL` を追加し、値として idobata の Custom Webhook 用 URL を記載します。

## 対応 issue

なし

## スクリーンショット

### 成功したとき

<img width="543" alt="_225__idobata" src="https://cloud.githubusercontent.com/assets/1979779/24333338/f45e9fcc-1290-11e7-994b-dcaf809c93b4.png">

### 失敗したとき

<img width="1197" alt="banners_and_alerts_and__225__idobata" src="https://cloud.githubusercontent.com/assets/1979779/24333342/04770386-1291-11e7-9a18-42e04683973e.png">
