### PR TITLE
rubocop の違反指摘が出ないようにコードを変えた

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,3 +80,6 @@ Style/TrailingCommaInLiteral:
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Style/Lambda:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ gem 'slim-rails'
 gem 'turbolinks'
 
 group :development, :test do
-  gem 'dotenv-rails'
   gem 'bullet'
+  gem 'dotenv-rails'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rubocop', require: false

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,5 +1,4 @@
 class Admin::ApplicationController < ApplicationController
-
   private
 
   def basic_authorization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,5 +10,4 @@ class ApplicationController < ActionController::Base
       user == ENV['USER_ID'] && pass == ENV['USER_PASS']
     end
   end
-
 end

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -58,8 +58,7 @@ class OrderItemsController < ApplicationController
   end
 
   def order_close_confirmation
-    redirect_to order_order_items_path(@order) , notice: '注文受付が締め切られたため注文できません' if @order.closed?
-    return
+    redirect_to order_order_items_path(@order), notice: '注文受付が締め切られたため注文できません' if @order.closed?
   end
 
   def set_order_item

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -26,8 +26,6 @@ class OrderItemsController < ApplicationController
     end
   end
 
-  def edit; end
-
   def update
     if @order_item.update(order_item_params)
       redirect_to order_order_items_path(@order_item.order), notice: '注文情報を更新しました'

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -26,8 +26,7 @@ class OrderItemsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @order_item.update(order_item_params)

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -40,15 +40,15 @@ class OrderItemsController < ApplicationController
     @order_item.destroy
     if @order_item
       notice = "#{@order_item.customer_name} さんの #{@order_item.lunchbox.name} の注文を取り消しました。"
-      redirect_to order_order_items_path(@order_item.order) , notice: notice
+      redirect_to order_order_items_path(@order_item.order), notice: notice
     end
   end
 
   def receive
     if @order_item.update(received_at: Time.current)
-      redirect_to order_order_items_path(@order_item.order) , notice: '注文した弁当を受け取りました'
+      redirect_to order_order_items_path(@order_item.order), notice: '注文した弁当を受け取りました'
     else
-      redirect_to order_order_items_path(@order_item.order) , alert: '予期せぬエラーが発生しました'
+      redirect_to order_order_items_path(@order_item.order), alert: '予期せぬエラーが発生しました'
     end
   end
 

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -37,10 +37,11 @@ class OrderItemsController < ApplicationController
   end
 
   def destroy
-    @order_item.destroy
-    if @order_item
+    if @order_item.destroy
       notice = "#{@order_item.customer_name} さんの #{@order_item.lunchbox.name} の注文を取り消しました。"
       redirect_to order_order_items_path(@order_item.order), notice: notice
+    else
+      redirect_to order_order_items_path(@order_item.order), alert: '予期せぬエラーが発生しました'
     end
   end
 

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -14,5 +14,4 @@ FactoryGirl.define do
     name 'sample弁当'
     price 400
   end
-
 end

--- a/spec/features/admin_orders_spec.rb
+++ b/spec/features/admin_orders_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin::Orders', type: :feature do
-
   before :each do
     admin_login
   end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -19,7 +19,6 @@ RSpec.feature 'Order', type: :feature do
   end
 
   feature '注文の新規作成' do
-
     scenario 'Order が締め切られている場合、注文者は新しく注文できない' do
       order = create(:order, :closed)
       visit new_order_order_item_path(order)
@@ -46,11 +45,9 @@ RSpec.feature 'Order', type: :feature do
       expect(page).not_to have_text(user_name)
       expect(page).to have_text('注文受付が締め切られたため注文できません')
       expect(page).to have_text('受取確認')
-
     end
 
     scenario '注文者が新しく注文する' do
-
       visit order_order_items_path(order)
       user_name = 'sample-user'
 
@@ -67,7 +64,6 @@ RSpec.feature 'Order', type: :feature do
       expect(page).to have_text(user_name)
       expect(page).to have_text('予約する')
       expect(page).to have_text('注文しました')
-
     end
   end
 
@@ -93,9 +89,7 @@ RSpec.feature 'Order', type: :feature do
       expect(page).to have_text(order_item.customer_name)
       expect(page).not_to have_link('予約取り消し')
     end
-
   end
-
 
   feature '注文の修正' do
     scenario '注文者は自分の注文を修正できる' do
@@ -130,7 +124,6 @@ RSpec.feature 'Order', type: :feature do
 
       expect(page).not_to have_link(order_item.customer_name)
     end
-
   end
 
   feature '注文の受取' do

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'Order', type: :feature do
     given(:order) { create(:order, :closed) }
 
     scenario '注文者は自分の注文した弁当を受け取ったことをシステムに知らせることが出来る' do
-      order_items = create(:order_item, order: order, lunchbox: lunchbox)
+      create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
       expect(page).to have_text('受取確認')

--- a/spec/support/basic_auth_helper.rb
+++ b/spec/support/basic_auth_helper.rb
@@ -1,5 +1,4 @@
 module BasicAuthHelper
-
   def user_login
     user_name = ENV['USER_ID']
     password = ENV['USER_PASS']
@@ -17,5 +16,4 @@ module BasicAuthHelper
     credentials = basic.encode_credentials(user_name, password)
     page.driver.header('Authorization', credentials)
   end
-
 end


### PR DESCRIPTION
## やったこと

現在の rubocop の設定どおりにコードを書き換えました。

`rubocop` コマンドでチェックを実行して、出てきた違反を単純に機械的に消していった（違反しないようなコードに変えた）だけなので、このうえで「この書き方はやっぱりやだからこうしよう」という話をみんなでできたらいいかなと思います。
コミットは違反の種類ごとに行っているので多少修正しやすくなっているはず...（コードの書き方を変えたいときには revert すればいいだけになるので）。

アプリケーションの動作に直接大きな影響があるわけではない変更ばかりなので、マージするのは急ぎません。