### PR TITLE
表現を統一する

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -3,9 +3,9 @@ class Admin::OrdersController < Admin::ApplicationController
     order = Order.find(params[:id])
 
     if order.close
-      redirect_to todays_order_admin_orders_path, notice: '注文を締め切りました'
+      redirect_to todays_order_admin_orders_path, notice: '予約を締め切りました'
     else
-      redirect_to todays_order_admin_orders_path, alert: '注文を締め切れませんでした'
+      redirect_to todays_order_admin_orders_path, alert: '予約を締め切れませんでした'
     end
   end
 end

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -20,7 +20,7 @@ class OrderItemsController < ApplicationController
     @order_item = @order.order_items.build(order_item_params)
 
     if @order_item.save
-      redirect_to order_order_items_path(@order), notice: '注文しました'
+      redirect_to order_order_items_path(@order), notice: '予約しました'
     else
       render :new
     end
@@ -28,7 +28,7 @@ class OrderItemsController < ApplicationController
 
   def update
     if @order_item.update(order_item_params)
-      redirect_to order_order_items_path(@order_item.order), notice: '注文情報を更新しました'
+      redirect_to order_order_items_path(@order_item.order), notice: '予約情報を更新しました'
     else
       render :edit
     end
@@ -36,7 +36,7 @@ class OrderItemsController < ApplicationController
 
   def destroy
     if @order_item.destroy
-      notice = "#{@order_item.customer_name} さんの #{@order_item.lunchbox.name} の注文を取り消しました。"
+      notice = "#{@order_item.customer_name} さんの #{@order_item.lunchbox.name} の予約を取り消しました。"
       redirect_to order_order_items_path(@order_item.order), notice: notice
     else
       redirect_to order_order_items_path(@order_item.order), alert: '予期せぬエラーが発生しました'
@@ -45,7 +45,7 @@ class OrderItemsController < ApplicationController
 
   def receive
     if @order_item.update(received_at: Time.current)
-      redirect_to order_order_items_path(@order_item.order), notice: '注文した弁当を受け取りました'
+      redirect_to order_order_items_path(@order_item.order), notice: '予約した弁当を受け取りました'
     else
       redirect_to order_order_items_path(@order_item.order), alert: '予期せぬエラーが発生しました'
     end
@@ -58,7 +58,7 @@ class OrderItemsController < ApplicationController
   end
 
   def order_close_confirmation
-    redirect_to order_order_items_path(@order), notice: '注文受付が締め切られたため注文できません' if @order.closed?
+    redirect_to order_order_items_path(@order), notice: '予約受付が締め切られたため予約できません' if @order.closed?
   end
 
   def set_order_item

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -5,9 +5,9 @@ module OrdersHelper
 
   def order_items_title(date)
     if date == Time.current.to_date
-      "今日（#{l(date)}）の注文一覧"
+      "今日（#{l(date)}）の予約一覧"
     else
-      "#{l(date)}の注文一覧"
+      "#{l(date)}の予約一覧"
     end
   end
 end

--- a/app/services/order_items_matrix.rb
+++ b/app/services/order_items_matrix.rb
@@ -7,7 +7,7 @@ class OrderItemsMatrix
     matrix = []
 
     grouped_items = ActiveRecord::Base.connection.select_all(aggregate_sql).rows.map do |lunchbox_id, num|
-      [lunchbox_id, num.to_i] # NOTE: 注文の入ってない弁当の数はnilになってるので0にする
+      [lunchbox_id, num.to_i] # NOTE: 予約の入ってない弁当の数はnilになってるので0にする
     end.to_h
     lunchboxes = Lunchbox.where(id: grouped_items.keys).to_a
 
@@ -23,7 +23,7 @@ class OrderItemsMatrix
 
   private
 
-  # NOTE: その日の注文数を弁当毎に集計するSQL
+  # NOTE: その日の予約数を弁当毎に集計するSQL
   def aggregate_sql
     sql = <<-SQL
     SELECT lunchboxes.id, lunchbox_count.cnt

--- a/app/views/admin/order_items/index.html.slim
+++ b/app/views/admin/order_items/index.html.slim
@@ -12,4 +12,4 @@ table.table.table-default
     = closed_info(@order)
 - else
   = form_tag close_admin_order_path(@order), method: :patch do
-    = submit_tag '注文を締め切る', class: 'btn btn-primary btn-lg'
+    = submit_tag '予約を締め切る', class: 'btn btn-primary btn-lg'

--- a/app/views/order_items/_form.html.slim
+++ b/app/views/order_items/_form.html.slim
@@ -15,4 +15,4 @@
       = f.label :lunchbox
       = f.select :lunchbox_id, Lunchbox.all.map {|l| [price_tag(l), l.id] }, {}, {class: 'form-control'}
 
-    = f.button '注文を確定する', class: 'btn btn-primary'
+    = f.button '予約を確定する', class: 'btn btn-primary'

--- a/app/views/order_items/edit.html.slim
+++ b/app/views/order_items/edit.html.slim
@@ -1,8 +1,8 @@
 h1
-  | 注文内容の更新
+  | 予約内容の更新
 = render partial: 'form', locals: {order: @order, order_item: @order_item}
 
 nav
   ul.nav.nav-pills.nav-stacked
-    li = link_to '注文日選択画面へもどる', orders_path
+    li = link_to '予約日選択画面へもどる', orders_path
     li = link_to "#{l(@order.date)} の予約一覧へもどる", order_order_items_path(@order)

--- a/app/views/order_items/index.html.slim
+++ b/app/views/order_items/index.html.slim
@@ -18,10 +18,10 @@ table.table.table-hover
               .text-center = '✓'
         td= link_to '予約取り消し', order_order_item_path(@order, item), \
           method: :delete, class: 'btn btn-danger', \
-          data: {confirm: '注文を取り消してよろしいですか？'}
+          data: {confirm: '予約を取り消してよろしいですか？'}
 
 = link_to "#{l(@order.date)} のお弁当を予約する", new_order_order_item_path(@order), class: 'btn btn-primary btn-lg'
 
 nav
   ul.nav.nav-pills.nav-stacked
-    li = link_to '注文日選択画面へもどる', orders_path
+    li = link_to '予約日選択画面へもどる', orders_path

--- a/app/views/order_items/new.html.slim
+++ b/app/views/order_items/new.html.slim
@@ -1,8 +1,8 @@
 h1
-  | 注文予約
+  | 新しく予約する
 = render partial: 'form', locals: {order: @order, order_item: @order_item}
 
 nav
   ul.nav.nav-pills.nav-stacked
-    li = link_to '注文日選択画面へもどる', orders_path
+    li = link_to '予約日選択画面へもどる', orders_path
     li = link_to "#{l(@order.date)} の予約一覧へもどる", order_order_items_path(@order)

--- a/app/views/order_items/receive.html.slim
+++ b/app/views/order_items/receive.html.slim
@@ -24,4 +24,4 @@ table.table.table-hover
 
 nav
   ul.nav.nav-pills.nav-stacked
-    li = link_to '注文日選択画面へもどる', orders_path
+    li = link_to '予約日選択画面へもどる', orders_path

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -3,18 +3,18 @@
     | 本日 (#{l(@today_order.date)}) のお弁当を受け取る
   -# TODO インタフェースとしてはイケてないけどとりあえずやりたいことはこういうこと
   p
-    | 本日の注文は締め切りました。受け取りチェックをするには以下のリンクをクリックしてください。
+    | 本日の予約は締め切りました。受け取りチェックをするには以下のリンクをクリックしてください。
   = link_to l(@today_order.date), order_order_items_path(@today_order)
 
 h2
-  | お弁当を注文する
+  | お弁当を予約する
 
 - if @orders.any?
   p
-    | 注文したい日付を選んでください。
+    | 予約したい日付を選んでください。
   - @orders.each do |order|
     ul
       li= link_to l(order.date), order_order_items_path(order)
 - else
   p
-    | 注文できる日がありません。管理者にお問い合わせください。
+    | 予約できる日がありません。管理者にお問い合わせください。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,9 +3,9 @@ ja:
   activerecord:
     attributes:
       order:
-        closed_at: 注文締め切り時間
+        closed_at: 予約締め切り時間
       order_item:
-        customer_name: 注文者名
+        customer_name: 予約者名
         lunchbox: 弁当
   time:
     formats:

--- a/spec/features/admin_orders_spec.rb
+++ b/spec/features/admin_orders_spec.rb
@@ -9,24 +9,24 @@ RSpec.feature 'Admin::Orders', type: :feature do
     given!(:order) { create(:order) }
     given!(:lunchbox) { create(:lunchbox) }
 
-    scenario '固定のURLで今日の予約状況を見れて、注文を締めることが出来る' do
+    scenario '固定のURLで今日の予約状況を見れて、予約を締めることが出来る' do
       Timecop.freeze(order.date) do
         create(:order_item, lunchbox_id: lunchbox.id, order: order)
         create(:order_item, lunchbox_id: lunchbox.id, order: order)
 
         visit todays_order_admin_orders_path
 
-        expect(page).to have_text("今日（#{I18n.l(order.date)}）の注文一覧")
+        expect(page).to have_text("今日（#{I18n.l(order.date)}）の予約一覧")
         expect(page).to have_text(lunchbox.name)
         expect(page).to have_text(2) # NOTE: 個数が表示される
         expect(page).to have_text(2 * lunchbox.price)
 
-        expect(page).not_to have_text('注文締め切り時間')
+        expect(page).not_to have_text('予約締め切り時間')
 
-        click_button('注文を締め切る')
+        click_button('予約を締め切る')
 
-        expect(page).to have_text('注文締め切り時間')
-        expect(page).not_to have_selector('input[type=submit][value="注文を締め切る"]')
+        expect(page).to have_text('予約締め切り時間')
+        expect(page).not_to have_selector('input[type=submit][value="予約を締め切る"]')
       end
     end
   end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -8,25 +8,25 @@ RSpec.feature 'Order', type: :feature do
     user_login
   end
 
-  feature '注文の確認' do
-    scenario '注文者は自分の注文を確認できる' do
+  feature '予約の確認' do
+    scenario '予約者は自分の予約を確認できる' do
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
       expect(page).to have_text(order_item.customer_name)
-      expect(page).to have_text('2017/02/01(水)の注文一覧')
+      expect(page).to have_text('2017/02/01(水)の予約一覧')
     end
   end
 
-  feature '注文の新規作成' do
-    scenario 'Order が締め切られている場合、注文者は新しく注文できない' do
+  feature '予約の新規作成' do
+    scenario 'Order が締め切られている場合、予約者は新しく予約できない' do
       order = create(:order, :closed)
       visit new_order_order_item_path(order)
 
       expect(page).to have_text('受取確認')
     end
 
-    scenario 'Order が締め切られている場合、注文者は新しい注文を確定できない' do
+    scenario 'Order が締め切られている場合、予約者は新しい予約を確定できない' do
       user_name = 'sample-user'
 
       visit order_order_items_path(order)
@@ -35,19 +35,19 @@ RSpec.feature 'Order', type: :feature do
       expect(page).not_to have_text(user_name)
 
       click_link('予約する')
-      fill_in '注文者名', with: 'customer'
+      fill_in '予約者名', with: 'customer'
       select lunchbox.name, from: 'order_item[lunchbox_id]'
 
       order.close(Time.zone.local(2017, 2, 1))
 
-      click_button '注文を確定する'
+      click_button '予約を確定する'
 
       expect(page).not_to have_text(user_name)
-      expect(page).to have_text('注文受付が締め切られたため注文できません')
+      expect(page).to have_text('予約受付が締め切られたため予約できません')
       expect(page).to have_text('受取確認')
     end
 
-    scenario '注文者が新しく注文する' do
+    scenario '予約者が新しく予約する' do
       visit order_order_items_path(order)
       user_name = 'sample-user'
 
@@ -55,20 +55,20 @@ RSpec.feature 'Order', type: :feature do
       expect(page).not_to have_text(user_name)
 
       click_link('予約する')
-      fill_in '注文者名', with: user_name
+      fill_in '予約者名', with: user_name
       select lunchbox.name, from: 'order_item[lunchbox_id]'
 
-      click_button '注文を確定する'
+      click_button '予約を確定する'
 
       # インデックスに戻る
       expect(page).to have_text(user_name)
       expect(page).to have_text('予約する')
-      expect(page).to have_text('注文しました')
+      expect(page).to have_text('予約しました')
     end
   end
 
-  feature '注文のキャンセル' do
-    scenario '注文者は自分の注文をキャンセルできる' do
+  feature '予約のキャンセル' do
+    scenario '予約者は自分の予約をキャンセルできる' do
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)
@@ -77,10 +77,10 @@ RSpec.feature 'Order', type: :feature do
 
       click_link('予約取り消し')
       expect(page).not_to have_text('予約取り消し')
-      expect(page).to have_text("#{order_item.customer_name} さんの #{order_item.lunchbox.name} の注文を取り消しました。")
+      expect(page).to have_text("#{order_item.customer_name} さんの #{order_item.lunchbox.name} の予約を取り消しました。")
     end
 
-    scenario 'Order が締め切られている場合、注文者は自分の注文をキャンセルできない' do
+    scenario 'Order が締め切られている場合、予約者は自分の予約をキャンセルできない' do
       order = create(:order, :closed)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
@@ -91,8 +91,8 @@ RSpec.feature 'Order', type: :feature do
     end
   end
 
-  feature '注文の修正' do
-    scenario '注文者は自分の注文を修正できる' do
+  feature '予約の修正' do
+    scenario '予約者は自分の予約を修正できる' do
       other_lunchbox = create(:lunchbox, name: 'sample弁当-上')
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
       new_name = 'another_name'
@@ -102,12 +102,12 @@ RSpec.feature 'Order', type: :feature do
       expect(page).to have_text(order_item.customer_name)
 
       click_link(order_item.customer_name)
-      fill_in '注文者名', with: new_name
+      fill_in '予約者名', with: new_name
 
       expect(page).to have_select('order_item[lunchbox_id]', selected: "#{lunchbox.name} (#{lunchbox.price}円)")
       select new_lunchbox_tag, from: 'order_item[lunchbox_id]'
 
-      click_button '注文を確定する'
+      click_button '予約を確定する'
 
       expect(page).not_to have_text(order_item.customer_name)
       expect(page).to have_text(new_name)
@@ -116,7 +116,7 @@ RSpec.feature 'Order', type: :feature do
       expect(page).to have_select('order_item[lunchbox_id]', selected: new_lunchbox_tag)
     end
 
-    scenario 'Order が締め切られている場合、注文者は自分の注文を編集できない' do
+    scenario 'Order が締め切られている場合、予約者は自分の予約を編集できない' do
       order = create(:order, :closed)
       order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
@@ -126,10 +126,10 @@ RSpec.feature 'Order', type: :feature do
     end
   end
 
-  feature '注文の受取' do
+  feature '予約の受取' do
     given(:order) { create(:order, :closed) }
 
-    scenario '注文者は自分の注文した弁当を受け取ったことをシステムに知らせることが出来る' do
+    scenario '予約者は自分の予約した弁当を受け取ったことをシステムに知らせることが出来る' do
       create(:order_item, order: order, lunchbox: lunchbox)
 
       visit order_order_items_path(order)


### PR DESCRIPTION
## やったこと

ひとまず「注文」を「予約」に置き換えてみました。わたしはこれでいいかなーと思っていますが、違和感があれば逆の変更をしてみます。

`app/views/order_items/new.html.slim` の `h1` は `注文予約` というカオスな名前だったので、 `新しく予約する` に変えました。

## 対応 issue

#68