### PR TITLE
予約している日がタイトルに出るようにした

### DIFF
--- a/app/views/order_items/edit.html.slim
+++ b/app/views/order_items/edit.html.slim
@@ -1,5 +1,5 @@
 h1
-  | 予約内容の更新
+  | 予約内容の更新(#{l(@order.date)} 分)
 = render partial: 'form', locals: {order: @order, order_item: @order_item}
 
 nav

--- a/app/views/order_items/new.html.slim
+++ b/app/views/order_items/new.html.slim
@@ -1,5 +1,5 @@
 h1
-  | 新しく予約する
+  | 新しく予約する(#{l(@order.date)} 分)
 = render partial: 'form', locals: {order: @order, order_item: @order_item}
 
 nav


### PR DESCRIPTION
## やったこと

お弁当の予約をしようとしてるときに、「あれ、いま自分はいつの予約フォームを開いてるんだ？」とたまに不安になるので、日付がタイトルに出るように変えました。

### 新規予約

![bento](https://cloud.githubusercontent.com/assets/1979779/24409264/adbf6a26-140a-11e7-9d1a-2312bbd61834.png)

### 予約内容更新

![bento](https://cloud.githubusercontent.com/assets/1979779/24409282/bfe04f04-140a-11e7-8fc8-d1d780b4c972.png)
