### PR TITLE
database.yml がなくて Travis がうごかないので直した

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ bundler_args: --without production
 cache: bundler
 
 before_script:
+  - cp config/database.yml.sample config/database.yml
   - bundle exec rake db:create
   - bundle exec rake db:migrate
 


### PR DESCRIPTION
## やったこと

TravisCI をうごかすにあたって、不足していた dababase.yml の設定を追記しました。