### PR TITLE
メールに直接貼れる注文内容を出力する

### DIFF
--- a/app/assets/stylesheets/_mail_template.scss
+++ b/app/assets/stylesheets/_mail_template.scss
@@ -1,5 +1,12 @@
 .mail-template {
-  background-color: #F2F2F2;
+  border-top: #2E9961 solid 2px;
+  border-right: #2E9961 dashed 1px;
+  border-bottom: #2E9961 dashed 1px;
+  border-left: #2E9961 solid 12px;
+
   padding: 20px;
-  border-radius: 10px;
+}
+
+.mail-template__order-list {
+  padding: 10px;
 }

--- a/app/assets/stylesheets/_mail_template.scss
+++ b/app/assets/stylesheets/_mail_template.scss
@@ -1,0 +1,5 @@
+.mail-template {
+  background-color: #F2F2F2;
+  padding: 20px;
+  border-radius: 10px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import 'bootstrap';
 
 @import 'flash_message';
+@import 'mail_template';

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -44,6 +44,13 @@ class Order < ApplicationRecord
     [reservation_number_table << reservation_number_table.sum, reservation_price_table << reservation_price_table.sum]
   end
 
+  def ordered_lunchboxes_and_count
+    grouped_order_items = order_items.joins(:lunchbox).group('lunchboxes.id').order('lunchboxes.id').count
+    grouped_order_items.map do |lunchbox_id, count|
+      {lunchbox: Lunchbox.find(lunchbox_id), count: count}
+    end
+  end
+
   private
 
   def aggregate_reservation_numbers(lunchbox_ids)

--- a/app/views/admin/order_items/_mail_template.html.slim
+++ b/app/views/admin/order_items/_mail_template.html.slim
@@ -1,10 +1,9 @@
 .mail-template
-  p
-    | 本日のお弁当の注文をお願いします。内容は以下のとおりです。
+  | 本日のお弁当の注文をお願いします。内容は以下のとおりです。
 
-  ul.order-list
+  .mail-template__order-list
     - @order.ordered_lunchboxes_and_count.each do |data|
-      li
-        = "#{data[:lunchbox].name}: #{data[:count]} 個"
-  p
-    | よろしくお願いいたします。
+      .order-list__order
+        = "- #{data[:lunchbox].name}: #{data[:count]} 個"
+
+  | よろしくお願いいたします。

--- a/app/views/admin/order_items/_mail_template.html.slim
+++ b/app/views/admin/order_items/_mail_template.html.slim
@@ -1,0 +1,10 @@
+.mail-template
+  p
+    | 本日のお弁当の注文をお願いします。内容は以下のとおりです。
+
+  ul.order-list
+    - @order.ordered_lunchboxes_and_count.each do |data|
+      li
+        = "#{data[:lunchbox].name}: #{data[:count]} 個"
+  p
+    | よろしくお願いいたします。

--- a/app/views/admin/order_items/index.html.slim
+++ b/app/views/admin/order_items/index.html.slim
@@ -9,6 +9,12 @@ table.table.table-default
 - if @order.closed?
   p
     = closed_info(@order)
+
+  p
+    | 以下の内容をコピーしてメールにそのまま貼り付けることができます。
+
+  = render 'mail_template'
+
 - else
   = form_tag close_admin_order_path(@order), method: :patch do
     = submit_tag '予約を締め切る', class: 'btn btn-primary btn-lg'

--- a/spec/features/admin/render_mail_template_spec.rb
+++ b/spec/features/admin/render_mail_template_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'お弁当やさんへのメールの文言を表示する', type: :feature do
+  given!(:order) { create(:order) }
+  given!(:jouben_dai) { create(:lunchbox, name: '上弁ライス大') }
+  given!(:tokuben_futsuu) { create(:lunchbox, name: '特弁ライス普') }
+
+  background do
+    Timecop.freeze(order.date) do
+      create_list(:order_item, 2, lunchbox: jouben_dai, order: order)
+      create_list(:order_item, 3, lunchbox: tokuben_futsuu, order: order)
+    end
+  end
+
+  context 'その日の予約を締め切る前' do
+    it 'メールの文言は表示されていない' do
+      Timecop.freeze(order.date) do
+        visit todays_order_admin_orders_path
+
+        text = '本日のお弁当の注文をお願いします。内容は以下のとおりです。- 上弁ライス大: 2 個- 特弁ライス普: 3 個よろしくお願いいたします。'
+
+        expect(page).not_to have_text text
+      end
+    end
+  end
+
+  context 'その日の予約を締め切った後' do
+    it '予約された弁当とその個数が整形されて表示される' do
+      Timecop.freeze(order.date) do
+        visit todays_order_admin_orders_path
+        click_button('予約を締め切る')
+
+        text = '本日のお弁当の注文をお願いします。内容は以下のとおりです。- 上弁ライス大: 2 個- 特弁ライス普: 3 個よろしくお願いいたします。'
+
+        within '.mail-template' do
+          expect(page).to have_text text
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
（ `separate-test-files` ブランチで rebase してあるのでちょっと diff が変ですが、そっちが先に commit される想定なのであとで消えるはず）

## やってること

メールに直接貼れる文面を出力するようにしています。

### order_item_matrix について

~~これを出していたのって、「お弁当の発注者の方が、FAX 用紙に転記するときにメニューごとの個数を把握したいから」だと思うんですが、それが最終的に既製品となって（すなわちメールに直接貼れる文面として）出力されるのであれば、もはや order_item_matrix は不要なんじゃないかなと思いました。~~

~~#102 のコンテキストを含んで話をすすめてしまいますが、出力のためのロジックも正直なところかんたんではないし（ここで書いてる SQL も別にかんたんではないかなと思いますが 😓 ）、ヘルパに分散して Ruby の層でデータを作るのとビューを作るのをがんばってしまうとこれまた見づらくなってしまうなという印象を受けたので、最終的にはコレ自体をできればなくしたいです。~~

~~まだ作りかけなのでまた修正したら push します。~~

## 対応 issue

#61