### PR TITLE
Purge deppbot security update

### DIFF
--- a/.deppbot.yml
+++ b/.deppbot.yml
@@ -1,5 +1,2 @@
-
 security_updates: false
 frequency: 7
-
-

--- a/.deppbot.yml
+++ b/.deppbot.yml
@@ -1,0 +1,5 @@
+
+security_updates: false
+frequency: 7
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -42,4 +42,3 @@ group :development do
   gem 'annotate'
   gem 'listen'
 end
-gem 'nokogiri', '>= 1.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,6 @@ DEPENDENCIES
   holiday_jp
   jquery-rails
   listen
-  nokogiri (>= 1.7.1)
   pg
   pry-byebug
   pry-rails


### PR DESCRIPTION
### 概要

以前話したSecurityUpdateの無効化を実行しました。

### 実施事項

#### Security update のrevert
deppbot のSecurityUpdate(#98)によって追加されたGemfile内のバージョン指定を取り消します。
`This reverts commit 20b1930b5b73370ec918d94b3fd71925d8904092.`

#### .deppbot.ymlの追加
deppbot用の設定ファイルを追加しました。
意図は下記二点です
 - 更新頻度の明示
 - SecurityUpdate無効化


### 備考
とくになし
