### PR TITLE
Errbit でエラー監視をする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 gem 'rails', '5.0.1'
 
+gem 'airbrake', '~> 5.0' # errbit から、バージョン指定しろとの指示
 gem 'bootstrap-sass'
 gem 'faraday'
 gem 'holiday_jp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    airbrake (5.8.1)
+      airbrake-ruby (~> 1.8)
+    airbrake-ruby (1.8.0)
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
@@ -231,6 +234,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (~> 5.0)
   annotate
   bootstrap-sass
   bullet

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,0 +1,8 @@
+Airbrake.configure do |config|
+  config.host = ENV['ERRBIT_HOST']
+  config.project_id = 1 # required, but any positive integer works
+  config.project_key = ENV['ERRBIT_PROJECT_KEY']
+
+  config.environment = Rails.env
+  config.ignore_environments = %w(development test)
+end


### PR DESCRIPTION
## やったこと

Errbit を使うための設定をしました。

Errbit のアプリ自体は既に Heroku にホスティングしてるので、この設定が入ったらもう使えるようになるはず。
URL は別途共有します。

手順は https://github.com/errbit/errbit/blob/master/docs/deployment/heroku.md のとおりに進めました。
admin は私のメアドなどを（環境変数で）入れてあり、ログインなどができることも確認済みです。

## 対応 issue

#99