### PR TITLE
予約が不成立だった場合はメールのコピペ用テンプレートを表示させない

### DIFF
--- a/app/views/admin/order_items/index.html.slim
+++ b/app/views/admin/order_items/index.html.slim
@@ -10,11 +10,12 @@ table.table.table-default
   p
     = closed_info(@order)
 
+- else
+  = form_tag close_admin_order_path(@order), method: :patch do
+    = submit_tag '予約を締め切る', class: 'btn btn-primary btn-lg'
+
+- if @order.closed? && @order.item_count_satisfied?
   p
     | 以下の内容をコピーしてメールにそのまま貼り付けることができます。
 
   = render 'mail_template'
-
-- else
-  = form_tag close_admin_order_path(@order), method: :patch do
-    = submit_tag '予約を締め切る', class: 'btn btn-primary btn-lg'


### PR DESCRIPTION
## やったこと
バグ修正です。
管理者が予約を締め切った時に、予約が成立していなくてもメールのテンプレートが出てしまっていたので修正しました。

## 備考

`@order.closed? && @order.item_count_satisfied?` といった書き方の部分をリファクタリングしたいのですが、それを同じ PR にしてしまうとバグ修正がマージされるのが遅くなってしまう可能性があるので、別 PR として出します。

## マージ順

こちらを一番最初にマージしたいです。（バグ修正なので緊急度高め）