### PR TITLE
成立・不成立を表すコードをリファクタリングしてる

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -5,6 +5,7 @@ class Admin::OrdersController < Admin::ApplicationController
     order = Order.find(params[:id])
     order.close!
 
+    # TODO: 例外を入れる PR がマージされたら、ここを realized? で書き換える
     if order.item_count_satisfied?
       Idobata.post_for_user "本日(#{I18n.l(order.date)})分の注文が成立しました:smiley:今日はお弁当があります:bento:"
     else

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -5,9 +5,7 @@ class OrderItemsController < ApplicationController
 
   def index
     # rubocop:disable Style/AndOr
-    if @order.not_realized?
-      redirect_to orders_path and return
-    end
+    redirect_to orders_path and return if @order.not_realized?
     # rubocop:enable Style/AndOr
 
     @lunchboxes = Lunchbox.all

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -5,7 +5,7 @@ class OrderItemsController < ApplicationController
 
   def index
     # rubocop:disable Style/AndOr
-    if @order.item_count_shortage? && @order.closed?
+    if @order.not_realized?
       redirect_to orders_path and return
     end
     # rubocop:enable Style/AndOr

--- a/app/helpers/admin/order_items_helper.rb
+++ b/app/helpers/admin/order_items_helper.rb
@@ -13,7 +13,7 @@ module Admin::OrderItemsHelper
   end
 
   def order_message
-    if @order.item_count_satisfied?
+    if @order.realized?
       content_tag :div, '本日のお弁当の注文をお願いします。', class: 'alert alert-info'
     else
       content_tag :div, '本日のお弁当の注文は不要です。', class: 'alert alert-danger'

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -30,12 +30,12 @@ class Order < ApplicationRecord
     closed_at?
   end
 
-  def item_count_satisfied?
-    self.order_items.count >= MINIMUM_ORDER_ITEM_COUNT
+  def realized?
+    closed? && item_count_satisfied?
   end
 
-  def item_count_shortage?
-    !item_count_satisfied?
+  def not_realized?
+    closed? && item_count_shortage?
   end
 
   def aggregate_items(lunchboxes)
@@ -63,5 +63,13 @@ class Order < ApplicationRecord
     numbers.zip(prices).map do |num, price|
       num * price
     end
+  end
+
+  def item_count_satisfied?
+    self.order_items.count >= MINIMUM_ORDER_ITEM_COUNT
+  end
+
+  def item_count_shortage?
+    !item_count_satisfied?
   end
 end

--- a/app/views/admin/order_items/index.html.slim
+++ b/app/views/admin/order_items/index.html.slim
@@ -18,7 +18,7 @@ table.table.table-bordered
   = form_tag close_admin_order_path(@order), method: :patch do
     = submit_tag '予約を締め切る', class: 'btn btn-primary btn-lg'
 
-- if @order.closed? && @order.item_count_satisfied?
+- if @order.realized?
   p
     | 以下の内容をコピーしてメールにそのまま貼り付けることができます。
 

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -1,14 +1,13 @@
-- if @today_order&.closed?
-  - if @today_order&.item_count_satisfied?
-    h2
-      | 本日 (#{l(@today_order.date)}) のお弁当を受け取る
-    / TODO インタフェースとしてはイケてないけどとりあえずやりたいことはこういうこと
-    p
-      | 本日の予約は締め切りました。受け取りチェックをするには以下のリンクをクリックしてください。
-    = link_to l(@today_order.date), order_order_items_path(@today_order)
-  - else
-    h2
-      | 本日 (#{l(@today_order.date)}) の発注は注文数不足のため注文されませんでした
+- if @today_order&.realized?
+  h2
+    | 本日 (#{l(@today_order.date)}) のお弁当を受け取る
+  / TODO インタフェースとしてはイケてないけどとりあえずやりたいことはこういうこと
+  p
+    | 本日の予約は締め切りました。受け取りチェックをするには以下のリンクをクリックしてください。
+  = link_to l(@today_order.date), order_order_items_path(@today_order)
+- else
+  h2
+    | 本日 (#{l(@today_order.date)}) の発注は注文数不足のため注文されませんでした
 h2
   | お弁当を予約する
 

--- a/spec/features/cancel_order_spec.rb
+++ b/spec/features/cancel_order_spec.rb
@@ -17,13 +17,12 @@ RSpec.feature '予約のキャンセル', type: :feature do
   end
 
   scenario '予約が締め切られている場合、予約者は自分の予約をキャンセルできない' do
-    order = create(:order, :closed)
-    create_list(:order_item, 2, order: order, lunchbox: lunchbox)
-    order_item = create(:order_item, order: order, lunchbox: lunchbox)
+    order_items = create_list(:order_item, 3, order: order, lunchbox: lunchbox)
+    order.close!
 
     visit order_order_items_path(order)
 
-    expect(page).to have_text(order_item.customer_name)
+    expect(page).to have_text(order_items[0].customer_name)
     expect(page).not_to have_link('予約取り消し')
   end
 end

--- a/spec/features/choose_other_lunchbox_spec.rb
+++ b/spec/features/choose_other_lunchbox_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature '予約の修正', type: :feature do
 
   scenario '予約が締め切られている場合、予約者は自分の予約を編集できない' do
     order = create(:order, :closed)
+    create_list(:order_item, 2, order: order, lunchbox: lunchbox)
     order_item = create(:order_item, order: order, lunchbox: lunchbox)
 
     visit order_order_items_path(order)

--- a/spec/features/choose_other_lunchbox_spec.rb
+++ b/spec/features/choose_other_lunchbox_spec.rb
@@ -29,12 +29,11 @@ RSpec.feature '予約の修正', type: :feature do
   end
 
   scenario '予約が締め切られている場合、予約者は自分の予約を編集できない' do
-    order = create(:order, :closed)
-    create_list(:order_item, 2, order: order, lunchbox: lunchbox)
-    order_item = create(:order_item, order: order, lunchbox: lunchbox)
+    order_items = create_list(:order_item, 3, order: order, lunchbox: lunchbox)
+    order.close!
 
     visit order_order_items_path(order)
 
-    expect(page).not_to have_link(order_item.customer_name)
+    expect(page).not_to have_link(order_items[0].customer_name)
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,25 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
-  describe '#aggregate_items' do
-    let!(:lunchbox1) { create(:lunchbox, name: '弁当1', price: 400) }
-    let!(:lunchbox2) { create(:lunchbox, name: '弁当2', price: 300) }
-    let!(:lunchbox3) { create(:lunchbox, name: '弁当3', price: 350) }
-    let(:order) { create(:order) }
+  let!(:lunchbox1) { create(:lunchbox, name: '弁当1', price: 400) }
+  let!(:lunchbox2) { create(:lunchbox, name: '弁当2', price: 300) }
+  let!(:lunchbox3) { create(:lunchbox, name: '弁当3', price: 350) }
+  let(:order) { create(:order) }
 
-    before do
+  describe '#aggregate_items' do
+    it '注文された弁当の個数と値段が集計される' do
       create(:order_item, order: order, lunchbox_id: lunchbox1.id)
       create_list(:order_item, 3, order: order, lunchbox_id: lunchbox2.id)
       create(:order_item, order: order, lunchbox_id: lunchbox1.id)
-    end
 
-    it '注文された弁当の個数と値段が集計される' do
       expect(order.aggregate_items(Lunchbox.all)).to eq(
         [
           [2, 3, 0, 5],
           [2 * lunchbox1.price, 3 * lunchbox2.price, 0 * lunchbox3.price * 0, (2 * lunchbox1.price) + (3 * lunchbox2.price) + (lunchbox3.price * 0)]
         ]
       )
+    end
+  end
+
+  describe '#realized?' do
+    it '「予約が締め切られている」かつ「予約数が満たされている」' do
+      order = create(:order, :closed)
+      create(:order_item, order: order, lunchbox_id: lunchbox1.id)
+      create_list(:order_item, 3, order: order, lunchbox_id: lunchbox2.id)
+
+      expect(order.realized?).to eq true
+    end
+  end
+
+  describe '#not_realized?' do
+    it '「予約が締め切られている」かつ「予約数が満たされていない」' do
+      order = create(:order, :closed)
+      create(:order_item, order: order, lunchbox_id: lunchbox1.id)
+      create_list(:order_item, 1, order: order, lunchbox_id: lunchbox2.id)
+
+      expect(order.not_realized?).to eq true
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe Order, type: :model do
   let(:order) { create(:order) }
 
   describe '#aggregate_items' do
-    it '注文された弁当の個数と値段が集計される' do
+    before do
       create(:order_item, order: order, lunchbox_id: lunchbox1.id)
       create_list(:order_item, 3, order: order, lunchbox_id: lunchbox2.id)
       create(:order_item, order: order, lunchbox_id: lunchbox1.id)
+    end
 
+    it '注文された弁当の個数と値段が集計される' do
       expect(order.aggregate_items(Lunchbox.all)).to eq(
         [
           [2, 3, 0, 5],
@@ -22,22 +24,28 @@ RSpec.describe Order, type: :model do
   end
 
   describe '#realized?' do
-    it '「予約が締め切られている」かつ「予約数が満たされている」' do
-      order = create(:order, :closed)
-      create(:order_item, order: order, lunchbox_id: lunchbox1.id)
-      create_list(:order_item, 3, order: order, lunchbox_id: lunchbox2.id)
+    before do
+      create_list(:order_item, 3, order: order, lunchbox_id: lunchbox1.id)
+      order.close!
+    end
 
-      expect(order.realized?).to eq true
+    context '「予約が締め切られている」かつ「予約数が満たされている」場合' do
+      it 'realized?メソッドがtrueを返すこと' do
+        expect(order.realized?).to eq true
+      end
     end
   end
 
   describe '#not_realized?' do
-    it '「予約が締め切られている」かつ「予約数が満たされていない」' do
-      order = create(:order, :closed)
-      create(:order_item, order: order, lunchbox_id: lunchbox1.id)
-      create_list(:order_item, 1, order: order, lunchbox_id: lunchbox2.id)
+    before do
+      create_list(:order_item, 1, order: order, lunchbox_id: lunchbox1.id)
+      order.close!
+    end
 
-      expect(order.not_realized?).to eq true
+    context '「予約が締め切られている」かつ「予約数が満たされていない」場合' do
+      it 'not_realized?メソッドがtrueを返すこと' do
+        expect(order.not_realized?).to eq true
+      end
     end
   end
 end


### PR DESCRIPTION
「予約が締め切られている」かつ「予約数が満たされている」という状態はつまり「予約が成立している」状態だと言えると思うのです。
それをそのままオブジェクトのふるまい（というか状態確認）として書いてより読みやすくしたかったので、リファクタリングしています。

## WIP をはずす条件

- [x] #127, #128 が変更の影響が大きいので、そのふたつがマージされること。
- [x] TODO が全部終わっていること。

## TODO

- [x] `realized?` の単体テストを書く
- [x]  `not_realized?` の単体テストを書く
- [x] `item_count_satisfied?` `item_count_shortage?` を private method にしたので、それを使っているテストがあったら適切な形に直す（ `realized?` では文脈的におかしいところがあったら、 private method から戻してもいいと思うけど、基本的にないんじゃないかなと想像してる）
- [x] フィーチャスペックが、変更なしでも通っていることを確認する

