### PR TITLE
一定時間がたったら自動的に消えるフラッシュメッセージ

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,3 +2,4 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require turbolinks
+//= require fadeout

--- a/app/assets/javascripts/fadeout.js
+++ b/app/assets/javascripts/fadeout.js
@@ -1,0 +1,3 @@
+$(function() {
+  $('.fadeout').fadeOut(7000);
+});

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html
       .container
         .flash-message
           - messages.each do |type, message|
-            .alert.alert-dismissible.fade.in(class="#{bootstrap_alert_class(type)}")
+            .alert.alert-dismissible.fadeout.fade.in(class="#{bootstrap_alert_class(type)}")
               = message
               button.close(data-dismiss='alert')
                 span(aria-hidden='true') &times;


### PR DESCRIPTION
## やること

ユーザのアクションが完了したときに出るフラッシュメッセージを、ずっと出しぱなしではなく、時間がたったら消えるようにします。

## 💭 考え中のこと
alert については、すぐ消えてしまうと困るときがあるかもしれない（どこを直したら正常に
 submit できるのかユーザは知りたいから）けど、https://github.com/colorbox/bento/pull/128/commits/77c570e3518183c410bcbe69000ecc1322ad391e で入力値のバリデートは HTML 側で表示させるようにした。そのため、alert のフラッシュメッセージは普通に使っている限りは出ることはないという認識でいる。とはいえなんらかの理由でメッセージが出る可能性もあるし、それならそういう方針で対応したほうがいいだろうし。考え中。

## TODO

- [x] べた書きしている JS を切り出す？
- [x] alert をどうするか考える => https://github.com/colorbox/bento/pull/135#issuecomment-301676833

## WIP をはずす条件

TODO がぜんぶ終わったらはずします。

## 対応 issue

#121 
