### PR TITLE
READMEの環境変数のセットアップを任意に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cp config/database.yml.sample config/database.yml
 bin/rails db:create db:migrate db:seed_fu
 ```
 
-3. 環境変数のセットアップ
+3. 環境変数のセットアップ（任意）
 
 
 ```
@@ -33,12 +33,12 @@ cp .env.sample .env
 
 エディタで `.env` を開き、必要な情報を追加
 
-- `ADMIN_ID`: 管理者（お弁当の注文を取りまとめる人）がダッシュボードにアクセスする際の ID（必須）
-- `ADMIN_PASS`: 管理者がダッシュボードにアクセスする際のパスワード（必須）
-- `USER_ID`: お弁当を頼みたい人がアクセスする際の ID（必須）
-- `USER_PASS`: お弁当を頼みたい人がアクセスする際のパスワード（必須）
-- `IDOBATA_DEVELOPER_HOOK_URL`: Order レコードが作成された際に通知を送る idobata room の WebHook URL（任意）
-- `IDOBATA_USER_HOOK_URL`: 注文が締め切られた時にお弁当の発注の可否の通知を送る idobata room の WebHook URL（任意）
+- `ADMIN_ID`: 管理者（お弁当の注文を取りまとめる人）がダッシュボードにアクセスする際の ID
+- `ADMIN_PASS`: 管理者がダッシュボードにアクセスする際のパスワード
+- `USER_ID`: お弁当を頼みたい人がアクセスする際の ID
+- `USER_PASS`: お弁当を頼みたい人がアクセスする際のパスワード
+- `IDOBATA_DEVELOPER_HOOK_URL`: Order レコードが作成された際に通知を送る idobata room の WebHook URL
+- `IDOBATA_USER_HOOK_URL`: 注文が締め切られた時にお弁当の発注の可否の通知を送る idobata room の WebHook URL
 
 4. サーバを起動
 


### PR DESCRIPTION
開発環境ではベーシック認証のセットアップは必要ないため必須を外し任意としました