### PR TITLE
管理画面に発注者向けメッセージを表示

### DIFF
--- a/app/helpers/admin/order_items_helper.rb
+++ b/app/helpers/admin/order_items_helper.rb
@@ -12,6 +12,14 @@ module Admin::OrderItemsHelper
     create_row(:td, number_body) + create_row(:td, price_body)
   end
 
+  def order_message
+    if @order.item_count_satisfied?
+      content_tag :div, '本日のお弁当の注文をお願いします。', class: 'alert alert-info'
+    else
+      content_tag :div, '本日のお弁当の注文は不要です。', class: 'alert alert-danger'
+    end
+  end
+
   private
 
   def create_row(t, texts)

--- a/app/views/admin/order_items/index.html.slim
+++ b/app/views/admin/order_items/index.html.slim
@@ -1,5 +1,9 @@
 h1 = order_items_title(@order.date)
 
+- if @order.closed?
+  .order-message.flash-message
+    = order_message
+
 table.table.table-bordered
   thead
     = admin_thead(@lunchboxes)

--- a/spec/features/admin/render_order_message_spec.rb
+++ b/spec/features/admin/render_order_message_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.feature '発注者へのメッセージを表示する', type: :feature do
+  given!(:order) { create(:order) }
+  given!(:jouben_dai) { create(:lunchbox, name: '上弁ライス大') }
+  given!(:tokuben_futsuu) { create(:lunchbox, name: '特弁ライス普') }
+  given(:order_needed_message) { '本日のお弁当の注文をお願いします。' }
+  given(:order_unneeded_message) { '本日のお弁当の注文は不要です。' }
+
+  context '当日の予約を締め切る前' do
+    background do
+      Timecop.freeze(order.date) do
+        create_list(:order_item, 2, lunchbox: jouben_dai, order: order)
+        create_list(:order_item, 3, lunchbox: tokuben_futsuu, order: order)
+      end
+    end
+
+    it 'メッセージは表示されていない' do
+      Timecop.freeze(order.date) do
+        visit todays_order_admin_orders_path
+
+        expect(page).not_to have_text order_needed_message
+      end
+    end
+  end
+
+  context '当日の予約を締め切った後' do
+    context '予約が成立したとき' do
+      background do
+        Timecop.freeze(order.date) do
+          create_list(:order_item, 2, lunchbox: jouben_dai, order: order)
+          create_list(:order_item, 3, lunchbox: tokuben_futsuu, order: order)
+        end
+      end
+
+      it '発注をお願いする旨のメッセージが表示される' do
+        Timecop.freeze(order.date) do
+          visit todays_order_admin_orders_path
+          click_button('予約を締め切る')
+
+          within '.order-message' do
+            expect(page).to have_text order_needed_message
+          end
+        end
+      end
+    end
+
+    context '予約が不成立だったとき' do
+      background do
+        Timecop.freeze(order.date) do
+          create_list(:order_item, 1, lunchbox: jouben_dai, order: order)
+          create_list(:order_item, 1, lunchbox: tokuben_futsuu, order: order)
+        end
+      end
+
+      it '発注が不要な旨のメッセージが表示される' do
+        Timecop.freeze(order.date) do
+          visit todays_order_admin_orders_path
+          click_button('予約を締め切る')
+
+          within '.order-message' do
+            expect(page).to have_text order_unneeded_message
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
connected to #134 

管理画面に注文が必要かどうかわかる文言を追加しました。
デザインはBootstrapを使用し、ロジックはhelperにまとめました。

![2017-05-15 16 08 08](https://cloud.githubusercontent.com/assets/16996739/26046208/c3e31b10-3988-11e7-9ee6-6f6d4b40a6bc.png)
